### PR TITLE
ADH-7592: Amoro add sort parameter into method getTablePartitions

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/DashboardServer.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/DashboardServer.java
@@ -32,6 +32,7 @@ import io.javalin.http.HttpCode;
 import io.javalin.http.staticfiles.Location;
 import io.javalin.http.staticfiles.StaticFileConfig;
 import org.apache.amoro.config.Configurations;
+import org.apache.amoro.exception.BadRequestException;
 import org.apache.amoro.exception.ForbiddenException;
 import org.apache.amoro.exception.SignatureCheckException;
 import org.apache.amoro.server.AmoroManagementConf;
@@ -408,11 +409,17 @@ public class DashboardServer {
       if (!ctx.req.getRequestURI().startsWith("/api/ams")) {
         ctx.html(getIndexFileContent());
       } else {
+        ctx.status(HttpCode.FORBIDDEN);
         ctx.json(new ErrorResponse(HttpCode.FORBIDDEN, "Please login first", ""));
       }
     } else if (e instanceof SignatureCheckException) {
+      ctx.status(HttpCode.FORBIDDEN);
       ctx.json(new ErrorResponse(HttpCode.FORBIDDEN, "Signature check failed", ""));
+    } else if (e instanceof BadRequestException) {
+      ctx.status(HttpCode.BAD_REQUEST);
+      ctx.json(new ErrorResponse(HttpCode.BAD_REQUEST, e.getMessage(), ""));
     } else {
+      ctx.status(HttpCode.INTERNAL_SERVER_ERROR);
       ctx.json(new ErrorResponse(HttpCode.INTERNAL_SERVER_ERROR, e.getMessage(), ""));
     }
     LOG.error("An error occurred while processing the url:{}", ctx.url(), e);

--- a/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/controller/TableController.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/controller/TableController.java
@@ -83,7 +83,17 @@ import org.apache.iceberg.SnapshotRef;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -94,7 +104,8 @@ import java.util.stream.Collectors;
 public class TableController {
   private static final Logger LOG = LoggerFactory.getLogger(TableController.class);
   private static final long UPGRADE_INFO_EXPIRE_INTERVAL = 60 * 60 * 1000;
-  private static final HashSet<String> validPartitionsTableSortFields = new HashSet<>(
+  private static final HashSet<String> validPartitionsTableSortFields =
+      new HashSet<>(
           Arrays.asList("partition", "specId", "fileCount", "fileSize", "lastCommitTime"));
 
   private final CatalogManager catalogManager;
@@ -472,8 +483,9 @@ public class TableController {
   private Comparator<PartitionBaseInfo> getPartitionComparator(String sortBy, String sortOrder) {
     if (sortBy == null || !validPartitionsTableSortFields.contains(sortBy)) {
       throw new IllegalArgumentException(
-        String.format("Invalid sortBy parameter: '%s'. Allowed values: %s",
-          sortBy, String.join(", ", validPartitionsTableSortFields)));
+          String.format(
+              "Invalid sortBy parameter: '%s'. Allowed values: %s",
+              sortBy, String.join(", ", validPartitionsTableSortFields)));
     }
 
     Comparator<PartitionBaseInfo> comparator;

--- a/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/controller/TableController.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/controller/TableController.java
@@ -28,6 +28,7 @@ import org.apache.amoro.api.CatalogMeta;
 import org.apache.amoro.api.OptimizingService;
 import org.apache.amoro.client.OptimizingClientPools;
 import org.apache.amoro.config.Configurations;
+import org.apache.amoro.exception.BadRequestException;
 import org.apache.amoro.hive.CachedHiveClientPool;
 import org.apache.amoro.hive.HMSClientPool;
 import org.apache.amoro.hive.catalog.MixedHiveCatalog;
@@ -478,11 +479,11 @@ public class TableController {
    *
    * @param sortBy - field name to sort by
    * @return Comparator for PartitionBaseInfo
-   * @throws IllegalArgumentException if sortBy is not a valid field
+   * @throws BadRequestException if sortBy is not a valid field
    */
   private Comparator<PartitionBaseInfo> getPartitionComparator(String sortBy, String sortOrder) {
     if (sortBy == null || !validPartitionsTableSortFields.contains(sortBy)) {
-      throw new IllegalArgumentException(
+      throw new BadRequestException(
           String.format(
               "Invalid sortBy parameter: '%s'. Allowed values: %s",
               sortBy, String.join(", ", validPartitionsTableSortFields)));
@@ -507,7 +508,7 @@ public class TableController {
         comparator = Comparator.comparingLong(PartitionBaseInfo::getLastCommitTime);
         break;
       default:
-        throw new IllegalArgumentException("Invalid sortBy parameter: " + sortBy);
+        throw new BadRequestException("Invalid sortBy parameter: " + sortBy);
     }
 
     if ("desc".equalsIgnoreCase(sortOrder)) {

--- a/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/controller/TableController.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/controller/TableController.java
@@ -83,15 +83,7 @@ import org.apache.iceberg.SnapshotRef;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
-import java.util.TreeMap;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -102,6 +94,8 @@ import java.util.stream.Collectors;
 public class TableController {
   private static final Logger LOG = LoggerFactory.getLogger(TableController.class);
   private static final long UPGRADE_INFO_EXPIRE_INTERVAL = 60 * 60 * 1000;
+  private static final HashSet<String> validPartitionsTableSortFields = new HashSet<>(
+          Arrays.asList("partition", "specId", "fileCount", "fileSize", "lastCommitTime"));
 
   private final CatalogManager catalogManager;
   private final TableManager tableManager;
@@ -451,6 +445,8 @@ public class TableController {
     String filter = ctx.queryParamAsClass("filter", String.class).getOrDefault("");
     Integer page = ctx.queryParamAsClass("page", Integer.class).getOrDefault(1);
     Integer pageSize = ctx.queryParamAsClass("pageSize", Integer.class).getOrDefault(20);
+    String sortBy = ctx.queryParamAsClass("sortBy", String.class).getOrDefault("partition");
+    String sortOrder = ctx.queryParamAsClass("sortOrder", String.class).getOrDefault("desc");
 
     List<PartitionBaseInfo> partitionBaseInfos =
         tableDescriptor.getTablePartition(
@@ -458,12 +454,55 @@ public class TableController {
     partitionBaseInfos =
         partitionBaseInfos.stream()
             .filter(e -> e.getPartition().contains(filter))
-            .sorted(Comparator.comparing(PartitionBaseInfo::getPartition).reversed())
+            .sorted(getPartitionComparator(sortBy, sortOrder))
             .collect(Collectors.toList());
     int offset = (page - 1) * pageSize;
     PageResult<PartitionBaseInfo> amsPageResult =
         PageResult.of(partitionBaseInfos, offset, pageSize);
     ctx.json(OkResponse.of(amsPageResult));
+  }
+
+  /**
+   * Get comparator for partition sorting based on the field name.
+   *
+   * @param sortBy - field name to sort by
+   * @return Comparator for PartitionBaseInfo
+   * @throws IllegalArgumentException if sortBy is not a valid field
+   */
+  private Comparator<PartitionBaseInfo> getPartitionComparator(String sortBy, String sortOrder) {
+    if (sortBy == null || !validPartitionsTableSortFields.contains(sortBy)) {
+      throw new IllegalArgumentException(
+        String.format("Invalid sortBy parameter: '%s'. Allowed values: %s",
+          sortBy, String.join(", ", validPartitionsTableSortFields)));
+    }
+
+    Comparator<PartitionBaseInfo> comparator;
+
+    switch (sortBy) {
+      case "partition":
+        comparator = Comparator.comparing(PartitionBaseInfo::getPartition);
+        break;
+      case "specId":
+        comparator = Comparator.comparingInt(PartitionBaseInfo::getSpecId);
+        break;
+      case "fileCount":
+        comparator = Comparator.comparingLong(PartitionBaseInfo::getFileCount);
+        break;
+      case "fileSize":
+        comparator = Comparator.comparingLong(PartitionBaseInfo::getFileSize);
+        break;
+      case "lastCommitTime":
+        comparator = Comparator.comparingLong(PartitionBaseInfo::getLastCommitTime);
+        break;
+      default:
+        throw new IllegalArgumentException("Invalid sortBy parameter: " + sortBy);
+    }
+
+    if ("desc".equalsIgnoreCase(sortOrder)) {
+      comparator = comparator.reversed();
+    }
+
+    return comparator;
   }
 
   /**

--- a/amoro-ams/src/main/resources/openapi/openapi.yaml
+++ b/amoro-ams/src/main/resources/openapi/openapi.yaml
@@ -38,6 +38,8 @@ tags:
     description: System and container settings
   - name: Overview
     description: Overview operations
+  - name: Tables
+    description: Table operations
 paths:
   /api/ams/v1/catalogs:
     get:
@@ -786,6 +788,76 @@ paths:
                     properties:
                       result:
                         type: boolean
+  /api/ams/v1/catalogs/{catalogName}/dbs/{db}/tables/{table}/partitions:
+    get:
+      tags:
+        - Tables
+      summary: Get table partitions
+      description: Get list of partitions for a specific table with optional sorting
+      parameters:
+        - name: catalogName
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The name of the catalog
+        - name: db
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The database name
+        - name: table
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The table name
+        - name: filter
+          in: query
+          schema:
+            type: string
+          description: Filter partitions by name
+        - name: page
+          in: query
+          schema:
+            type: integer
+            default: 1
+          description: Page number
+        - name: pageSize
+          in: query
+          schema:
+            type: integer
+            default: 20
+          description: Number of items per page
+        - name: sortBy
+          in: query
+          schema:
+            type: string
+            enum: [partition, specId, fileCount, fileSize, lastCommitTime]
+            default: partition
+          description: Field to sort by
+        - name: sortOrder
+          in: query
+          schema:
+            type: string
+            enum: [asc, desc]
+            default: desc
+          description: Sort order (ascending or descending)
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Response'
+                  - type: object
+                    properties:
+                      result:
+                        $ref: '#/components/schemas/PageResult'
+        '400':
+          description: Invalid sortBy parameter
 components:
   securitySchemes:
     ApiKeyAuth:
@@ -980,3 +1052,34 @@ components:
           type: object
           additionalProperties:
             type: string
+    PageResult:
+      type: object
+      properties:
+        list:
+          type: array
+          items:
+            $ref: '#/components/schemas/PartitionBaseInfo'
+        total:
+          type: integer
+        offset:
+          type: integer
+        pageSize:
+          type: integer
+    PartitionBaseInfo:
+      type: object
+      properties:
+        partition:
+          type: string
+        specId:
+          type: integer
+        fileCount:
+          type: integer
+          format: int64
+        fileSize:
+          type: integer
+          format: int64
+        lastCommitTime:
+          type: integer
+          format: int64
+        size:
+          type: string

--- a/amoro-ams/src/test/java/org/apache/amoro/server/dashboard/controller/TableControllerTest.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/dashboard/controller/TableControllerTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.amoro.server.dashboard.controller;
 
+import org.apache.amoro.exception.BadRequestException;
 import org.apache.amoro.table.descriptor.PartitionBaseInfo;
 import org.junit.Assert;
 import org.junit.Test;
@@ -202,14 +203,14 @@ public class TableControllerTest {
     Assert.assertEquals(1, sorted.get(3).getSpecId());
   }
 
-  /** Test that invalid sortBy parameter throws IllegalArgumentException. */
-  @Test(expected = IllegalArgumentException.class)
+  /** Test that invalid sortBy parameter throws BadRequestException. */
+  @Test(expected = BadRequestException.class)
   public void testInvalidSortByParameter() throws Exception {
     invokeGetPartitionComparator("invalidField", "asc");
   }
 
-  /** Test that null sortBy parameter throws IllegalArgumentException. */
-  @Test(expected = IllegalArgumentException.class)
+  /** Test that null sortBy parameter throws BadRequestException. */
+  @Test(expected = BadRequestException.class)
   public void testNullSortByParameter() throws Exception {
     invokeGetPartitionComparator(null, "asc");
   }

--- a/amoro-ams/src/test/java/org/apache/amoro/server/dashboard/controller/TableControllerTest.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/dashboard/controller/TableControllerTest.java
@@ -40,8 +40,7 @@ public class TableControllerTest {
         new PartitionBaseInfo("partition_a", 1, 100, 1000, 1609459200000L),
         new PartitionBaseInfo("partition_b", 2, 200, 2000, 1609545600000L),
         new PartitionBaseInfo("partition_c", 3, 150, 1500, 1609372800000L),
-        new PartitionBaseInfo("partition_d", 1, 50, 500, 1609632000000L)
-    );
+        new PartitionBaseInfo("partition_d", 1, 50, 500, 1609632000000L));
   }
 
   /**
@@ -52,9 +51,12 @@ public class TableControllerTest {
    * @return Comparator for PartitionBaseInfo
    * @throws Exception if reflection fails
    */
-  private Comparator<PartitionBaseInfo> invokeGetPartitionComparator(String sortBy, String sortOrder) throws Exception {
+  private Comparator<PartitionBaseInfo> invokeGetPartitionComparator(
+      String sortBy, String sortOrder) throws Exception {
     TableController controller = new TableController(null, null, null, null);
-    Method method = TableController.class.getDeclaredMethod("getPartitionComparator", String.class, String.class);
+    Method method =
+        TableController.class.getDeclaredMethod(
+            "getPartitionComparator", String.class, String.class);
     method.setAccessible(true);
     try {
       return (Comparator<PartitionBaseInfo>) method.invoke(controller, sortBy, sortOrder);
@@ -73,11 +75,10 @@ public class TableControllerTest {
   public void testSortByPartitionAsc() throws Exception {
     List<PartitionBaseInfo> partitions = createTestPartitions();
     Comparator<PartitionBaseInfo> comparator = invokeGetPartitionComparator("partition", "asc");
-    
-    List<PartitionBaseInfo> sorted = partitions.stream()
-        .sorted(comparator)
-        .collect(Collectors.toList());
-    
+
+    List<PartitionBaseInfo> sorted =
+        partitions.stream().sorted(comparator).collect(Collectors.toList());
+
     Assert.assertEquals("partition_a", sorted.get(0).getPartition());
     Assert.assertEquals("partition_d", sorted.get(3).getPartition());
   }
@@ -87,11 +88,10 @@ public class TableControllerTest {
   public void testSortByPartitionDesc() throws Exception {
     List<PartitionBaseInfo> partitions = createTestPartitions();
     Comparator<PartitionBaseInfo> comparator = invokeGetPartitionComparator("partition", "desc");
-    
-    List<PartitionBaseInfo> sorted = partitions.stream()
-        .sorted(comparator)
-        .collect(Collectors.toList());
-    
+
+    List<PartitionBaseInfo> sorted =
+        partitions.stream().sorted(comparator).collect(Collectors.toList());
+
     Assert.assertEquals("partition_d", sorted.get(0).getPartition());
     Assert.assertEquals("partition_a", sorted.get(3).getPartition());
   }
@@ -101,11 +101,10 @@ public class TableControllerTest {
   public void testSortByFileCountAsc() throws Exception {
     List<PartitionBaseInfo> partitions = createTestPartitions();
     Comparator<PartitionBaseInfo> comparator = invokeGetPartitionComparator("fileCount", "asc");
-    
-    List<PartitionBaseInfo> sorted = partitions.stream()
-        .sorted(comparator)
-        .collect(Collectors.toList());
-    
+
+    List<PartitionBaseInfo> sorted =
+        partitions.stream().sorted(comparator).collect(Collectors.toList());
+
     Assert.assertEquals(50, sorted.get(0).getFileCount());
     Assert.assertEquals(200, sorted.get(3).getFileCount());
   }
@@ -115,11 +114,10 @@ public class TableControllerTest {
   public void testSortByFileCountDesc() throws Exception {
     List<PartitionBaseInfo> partitions = createTestPartitions();
     Comparator<PartitionBaseInfo> comparator = invokeGetPartitionComparator("fileCount", "desc");
-    
-    List<PartitionBaseInfo> sorted = partitions.stream()
-        .sorted(comparator)
-        .collect(Collectors.toList());
-    
+
+    List<PartitionBaseInfo> sorted =
+        partitions.stream().sorted(comparator).collect(Collectors.toList());
+
     Assert.assertEquals(200, sorted.get(0).getFileCount());
     Assert.assertEquals(50, sorted.get(3).getFileCount());
   }
@@ -129,11 +127,10 @@ public class TableControllerTest {
   public void testSortByFileSizeAsc() throws Exception {
     List<PartitionBaseInfo> partitions = createTestPartitions();
     Comparator<PartitionBaseInfo> comparator = invokeGetPartitionComparator("fileSize", "asc");
-    
-    List<PartitionBaseInfo> sorted = partitions.stream()
-        .sorted(comparator)
-        .collect(Collectors.toList());
-    
+
+    List<PartitionBaseInfo> sorted =
+        partitions.stream().sorted(comparator).collect(Collectors.toList());
+
     Assert.assertEquals(500, sorted.get(0).getFileSize());
     Assert.assertEquals(2000, sorted.get(3).getFileSize());
   }
@@ -143,11 +140,10 @@ public class TableControllerTest {
   public void testSortByFileSizeDesc() throws Exception {
     List<PartitionBaseInfo> partitions = createTestPartitions();
     Comparator<PartitionBaseInfo> comparator = invokeGetPartitionComparator("fileSize", "desc");
-    
-    List<PartitionBaseInfo> sorted = partitions.stream()
-        .sorted(comparator)
-        .collect(Collectors.toList());
-    
+
+    List<PartitionBaseInfo> sorted =
+        partitions.stream().sorted(comparator).collect(Collectors.toList());
+
     Assert.assertEquals(2000, sorted.get(0).getFileSize());
     Assert.assertEquals(500, sorted.get(3).getFileSize());
   }
@@ -156,12 +152,12 @@ public class TableControllerTest {
   @Test
   public void testSortByLastCommitTimeAsc() throws Exception {
     List<PartitionBaseInfo> partitions = createTestPartitions();
-    Comparator<PartitionBaseInfo> comparator = invokeGetPartitionComparator("lastCommitTime", "asc");
-    
-    List<PartitionBaseInfo> sorted = partitions.stream()
-        .sorted(comparator)
-        .collect(Collectors.toList());
-    
+    Comparator<PartitionBaseInfo> comparator =
+        invokeGetPartitionComparator("lastCommitTime", "asc");
+
+    List<PartitionBaseInfo> sorted =
+        partitions.stream().sorted(comparator).collect(Collectors.toList());
+
     Assert.assertEquals(1609372800000L, sorted.get(0).getLastCommitTime());
     Assert.assertEquals(1609632000000L, sorted.get(3).getLastCommitTime());
   }
@@ -170,12 +166,12 @@ public class TableControllerTest {
   @Test
   public void testSortByLastCommitTimeDesc() throws Exception {
     List<PartitionBaseInfo> partitions = createTestPartitions();
-    Comparator<PartitionBaseInfo> comparator = invokeGetPartitionComparator("lastCommitTime", "desc");
-    
-    List<PartitionBaseInfo> sorted = partitions.stream()
-        .sorted(comparator)
-        .collect(Collectors.toList());
-    
+    Comparator<PartitionBaseInfo> comparator =
+        invokeGetPartitionComparator("lastCommitTime", "desc");
+
+    List<PartitionBaseInfo> sorted =
+        partitions.stream().sorted(comparator).collect(Collectors.toList());
+
     Assert.assertEquals(1609632000000L, sorted.get(0).getLastCommitTime());
     Assert.assertEquals(1609372800000L, sorted.get(3).getLastCommitTime());
   }
@@ -185,11 +181,10 @@ public class TableControllerTest {
   public void testSortBySpecIdAsc() throws Exception {
     List<PartitionBaseInfo> partitions = createTestPartitions();
     Comparator<PartitionBaseInfo> comparator = invokeGetPartitionComparator("specId", "asc");
-    
-    List<PartitionBaseInfo> sorted = partitions.stream()
-        .sorted(comparator)
-        .collect(Collectors.toList());
-    
+
+    List<PartitionBaseInfo> sorted =
+        partitions.stream().sorted(comparator).collect(Collectors.toList());
+
     Assert.assertEquals(1, sorted.get(0).getSpecId());
     Assert.assertEquals(3, sorted.get(3).getSpecId());
   }
@@ -199,11 +194,10 @@ public class TableControllerTest {
   public void testSortBySpecIdDesc() throws Exception {
     List<PartitionBaseInfo> partitions = createTestPartitions();
     Comparator<PartitionBaseInfo> comparator = invokeGetPartitionComparator("specId", "desc");
-    
-    List<PartitionBaseInfo> sorted = partitions.stream()
-        .sorted(comparator)
-        .collect(Collectors.toList());
-    
+
+    List<PartitionBaseInfo> sorted =
+        partitions.stream().sorted(comparator).collect(Collectors.toList());
+
     Assert.assertEquals(3, sorted.get(0).getSpecId());
     Assert.assertEquals(1, sorted.get(3).getSpecId());
   }
@@ -234,17 +228,15 @@ public class TableControllerTest {
   @Test
   public void testSortOrderCaseInsensitive() throws Exception {
     List<PartitionBaseInfo> partitions = createTestPartitions();
-    
+
     Comparator<PartitionBaseInfo> comparator1 = invokeGetPartitionComparator("fileCount", "DESC");
     Comparator<PartitionBaseInfo> comparator2 = invokeGetPartitionComparator("fileCount", "desc");
-    
-    List<PartitionBaseInfo> sorted1 = partitions.stream()
-        .sorted(comparator1)
-        .collect(Collectors.toList());
-    List<PartitionBaseInfo> sorted2 = partitions.stream()
-        .sorted(comparator2)
-        .collect(Collectors.toList());
-    
+
+    List<PartitionBaseInfo> sorted1 =
+        partitions.stream().sorted(comparator1).collect(Collectors.toList());
+    List<PartitionBaseInfo> sorted2 =
+        partitions.stream().sorted(comparator2).collect(Collectors.toList());
+
     Assert.assertEquals(sorted1.get(0).getFileCount(), sorted2.get(0).getFileCount());
   }
 }

--- a/amoro-ams/src/test/java/org/apache/amoro/server/dashboard/controller/TableControllerTest.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/dashboard/controller/TableControllerTest.java
@@ -1,0 +1,250 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.amoro.server.dashboard.controller;
+
+import org.apache.amoro.table.descriptor.PartitionBaseInfo;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class TableControllerTest {
+
+  /**
+   * Creates test partition data with varying values for sorting tests.
+   *
+   * @return List of test partitions
+   */
+  private List<PartitionBaseInfo> createTestPartitions() {
+    return Arrays.asList(
+        new PartitionBaseInfo("partition_a", 1, 100, 1000, 1609459200000L),
+        new PartitionBaseInfo("partition_b", 2, 200, 2000, 1609545600000L),
+        new PartitionBaseInfo("partition_c", 3, 150, 1500, 1609372800000L),
+        new PartitionBaseInfo("partition_d", 1, 50, 500, 1609632000000L)
+    );
+  }
+
+  /**
+   * Invokes the private getPartitionComparator method via reflection.
+   *
+   * @param sortBy field name to sort by
+   * @param sortOrder sort order ("asc" or "desc")
+   * @return Comparator for PartitionBaseInfo
+   * @throws Exception if reflection fails
+   */
+  private Comparator<PartitionBaseInfo> invokeGetPartitionComparator(String sortBy, String sortOrder) throws Exception {
+    TableController controller = new TableController(null, null, null, null);
+    Method method = TableController.class.getDeclaredMethod("getPartitionComparator", String.class, String.class);
+    method.setAccessible(true);
+    try {
+      return (Comparator<PartitionBaseInfo>) method.invoke(controller, sortBy, sortOrder);
+    } catch (java.lang.reflect.InvocationTargetException e) {
+      // Unwrap the exception thrown by the invoked method
+      Throwable cause = e.getCause();
+      if (cause instanceof Exception) {
+        throw (Exception) cause;
+      }
+      throw e;
+    }
+  }
+
+  /** Test sorting by partition name in ascending order. */
+  @Test
+  public void testSortByPartitionAsc() throws Exception {
+    List<PartitionBaseInfo> partitions = createTestPartitions();
+    Comparator<PartitionBaseInfo> comparator = invokeGetPartitionComparator("partition", "asc");
+    
+    List<PartitionBaseInfo> sorted = partitions.stream()
+        .sorted(comparator)
+        .collect(Collectors.toList());
+    
+    Assert.assertEquals("partition_a", sorted.get(0).getPartition());
+    Assert.assertEquals("partition_d", sorted.get(3).getPartition());
+  }
+
+  /** Test sorting by partition name in descending order. */
+  @Test
+  public void testSortByPartitionDesc() throws Exception {
+    List<PartitionBaseInfo> partitions = createTestPartitions();
+    Comparator<PartitionBaseInfo> comparator = invokeGetPartitionComparator("partition", "desc");
+    
+    List<PartitionBaseInfo> sorted = partitions.stream()
+        .sorted(comparator)
+        .collect(Collectors.toList());
+    
+    Assert.assertEquals("partition_d", sorted.get(0).getPartition());
+    Assert.assertEquals("partition_a", sorted.get(3).getPartition());
+  }
+
+  /** Test sorting by file count in ascending order. */
+  @Test
+  public void testSortByFileCountAsc() throws Exception {
+    List<PartitionBaseInfo> partitions = createTestPartitions();
+    Comparator<PartitionBaseInfo> comparator = invokeGetPartitionComparator("fileCount", "asc");
+    
+    List<PartitionBaseInfo> sorted = partitions.stream()
+        .sorted(comparator)
+        .collect(Collectors.toList());
+    
+    Assert.assertEquals(50, sorted.get(0).getFileCount());
+    Assert.assertEquals(200, sorted.get(3).getFileCount());
+  }
+
+  /** Test sorting by file count in descending order. */
+  @Test
+  public void testSortByFileCountDesc() throws Exception {
+    List<PartitionBaseInfo> partitions = createTestPartitions();
+    Comparator<PartitionBaseInfo> comparator = invokeGetPartitionComparator("fileCount", "desc");
+    
+    List<PartitionBaseInfo> sorted = partitions.stream()
+        .sorted(comparator)
+        .collect(Collectors.toList());
+    
+    Assert.assertEquals(200, sorted.get(0).getFileCount());
+    Assert.assertEquals(50, sorted.get(3).getFileCount());
+  }
+
+  /** Test sorting by file size in ascending order. */
+  @Test
+  public void testSortByFileSizeAsc() throws Exception {
+    List<PartitionBaseInfo> partitions = createTestPartitions();
+    Comparator<PartitionBaseInfo> comparator = invokeGetPartitionComparator("fileSize", "asc");
+    
+    List<PartitionBaseInfo> sorted = partitions.stream()
+        .sorted(comparator)
+        .collect(Collectors.toList());
+    
+    Assert.assertEquals(500, sorted.get(0).getFileSize());
+    Assert.assertEquals(2000, sorted.get(3).getFileSize());
+  }
+
+  /** Test sorting by file size in descending order. */
+  @Test
+  public void testSortByFileSizeDesc() throws Exception {
+    List<PartitionBaseInfo> partitions = createTestPartitions();
+    Comparator<PartitionBaseInfo> comparator = invokeGetPartitionComparator("fileSize", "desc");
+    
+    List<PartitionBaseInfo> sorted = partitions.stream()
+        .sorted(comparator)
+        .collect(Collectors.toList());
+    
+    Assert.assertEquals(2000, sorted.get(0).getFileSize());
+    Assert.assertEquals(500, sorted.get(3).getFileSize());
+  }
+
+  /** Test sorting by last commit time in ascending order. */
+  @Test
+  public void testSortByLastCommitTimeAsc() throws Exception {
+    List<PartitionBaseInfo> partitions = createTestPartitions();
+    Comparator<PartitionBaseInfo> comparator = invokeGetPartitionComparator("lastCommitTime", "asc");
+    
+    List<PartitionBaseInfo> sorted = partitions.stream()
+        .sorted(comparator)
+        .collect(Collectors.toList());
+    
+    Assert.assertEquals(1609372800000L, sorted.get(0).getLastCommitTime());
+    Assert.assertEquals(1609632000000L, sorted.get(3).getLastCommitTime());
+  }
+
+  /** Test sorting by last commit time in descending order. */
+  @Test
+  public void testSortByLastCommitTimeDesc() throws Exception {
+    List<PartitionBaseInfo> partitions = createTestPartitions();
+    Comparator<PartitionBaseInfo> comparator = invokeGetPartitionComparator("lastCommitTime", "desc");
+    
+    List<PartitionBaseInfo> sorted = partitions.stream()
+        .sorted(comparator)
+        .collect(Collectors.toList());
+    
+    Assert.assertEquals(1609632000000L, sorted.get(0).getLastCommitTime());
+    Assert.assertEquals(1609372800000L, sorted.get(3).getLastCommitTime());
+  }
+
+  /** Test sorting by spec ID in ascending order. */
+  @Test
+  public void testSortBySpecIdAsc() throws Exception {
+    List<PartitionBaseInfo> partitions = createTestPartitions();
+    Comparator<PartitionBaseInfo> comparator = invokeGetPartitionComparator("specId", "asc");
+    
+    List<PartitionBaseInfo> sorted = partitions.stream()
+        .sorted(comparator)
+        .collect(Collectors.toList());
+    
+    Assert.assertEquals(1, sorted.get(0).getSpecId());
+    Assert.assertEquals(3, sorted.get(3).getSpecId());
+  }
+
+  /** Test sorting by spec ID in descending order. */
+  @Test
+  public void testSortBySpecIdDesc() throws Exception {
+    List<PartitionBaseInfo> partitions = createTestPartitions();
+    Comparator<PartitionBaseInfo> comparator = invokeGetPartitionComparator("specId", "desc");
+    
+    List<PartitionBaseInfo> sorted = partitions.stream()
+        .sorted(comparator)
+        .collect(Collectors.toList());
+    
+    Assert.assertEquals(3, sorted.get(0).getSpecId());
+    Assert.assertEquals(1, sorted.get(3).getSpecId());
+  }
+
+  /** Test that invalid sortBy parameter throws IllegalArgumentException. */
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidSortByParameter() throws Exception {
+    invokeGetPartitionComparator("invalidField", "asc");
+  }
+
+  /** Test that null sortBy parameter throws IllegalArgumentException. */
+  @Test(expected = IllegalArgumentException.class)
+  public void testNullSortByParameter() throws Exception {
+    invokeGetPartitionComparator(null, "asc");
+  }
+
+  /** Test that all valid sort fields work correctly. */
+  @Test
+  public void testValidSortFields() throws Exception {
+    invokeGetPartitionComparator("partition", "asc");
+    invokeGetPartitionComparator("specId", "desc");
+    invokeGetPartitionComparator("fileCount", "asc");
+    invokeGetPartitionComparator("fileSize", "desc");
+    invokeGetPartitionComparator("lastCommitTime", "asc");
+  }
+
+  /** Test that sortOrder parameter is case insensitive. */
+  @Test
+  public void testSortOrderCaseInsensitive() throws Exception {
+    List<PartitionBaseInfo> partitions = createTestPartitions();
+    
+    Comparator<PartitionBaseInfo> comparator1 = invokeGetPartitionComparator("fileCount", "DESC");
+    Comparator<PartitionBaseInfo> comparator2 = invokeGetPartitionComparator("fileCount", "desc");
+    
+    List<PartitionBaseInfo> sorted1 = partitions.stream()
+        .sorted(comparator1)
+        .collect(Collectors.toList());
+    List<PartitionBaseInfo> sorted2 = partitions.stream()
+        .sorted(comparator2)
+        .collect(Collectors.toList());
+    
+    Assert.assertEquals(sorted1.get(0).getFileCount(), sorted2.get(0).getFileCount());
+  }
+}

--- a/amoro-common/src/main/java/org/apache/amoro/ErrorCodes.java
+++ b/amoro-common/src/main/java/org/apache/amoro/ErrorCodes.java
@@ -27,6 +27,7 @@ public final class ErrorCodes {
   public static final int ALREADY_EXISTS_ERROR_CODE = 1002;
   public static final int ILLEGAL_METADATA_ERROR_CODE = 1003;
   public static final int FORBIDDEN_ERROR_CODE = 1004;
+  public static final int BAD_REQUEST_ERROR_CODE = 1005;
 
   public static final int TASK_NOT_FOUND_ERROR_CODE = 2001;
   public static final int TASK_RUNTIME_ERROR_CODE = 2002;

--- a/amoro-common/src/main/java/org/apache/amoro/exception/AmoroRuntimeException.java
+++ b/amoro-common/src/main/java/org/apache/amoro/exception/AmoroRuntimeException.java
@@ -44,6 +44,7 @@ public class AmoroRuntimeException extends RuntimeException {
     CODE_MAP.put(AlreadyExistsException.class, ErrorCodes.ALREADY_EXISTS_ERROR_CODE);
     CODE_MAP.put(IllegalMetadataException.class, ErrorCodes.ILLEGAL_METADATA_ERROR_CODE);
     CODE_MAP.put(ForbiddenException.class, ErrorCodes.FORBIDDEN_ERROR_CODE);
+    CODE_MAP.put(BadRequestException.class, ErrorCodes.BAD_REQUEST_ERROR_CODE);
 
     CODE_MAP.put(TaskNotFoundException.class, ErrorCodes.TASK_NOT_FOUND_ERROR_CODE);
     CODE_MAP.put(TaskRuntimeException.class, ErrorCodes.TASK_RUNTIME_ERROR_CODE);

--- a/amoro-common/src/main/java/org/apache/amoro/exception/BadRequestException.java
+++ b/amoro-common/src/main/java/org/apache/amoro/exception/BadRequestException.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.amoro.exception;
+
+/**
+ * Exception indicating that the client request contains invalid parameters or malformed data. This
+ * exception should be used for validation errors and will result in HTTP 400 Bad Request.
+ */
+public class BadRequestException extends AmoroRuntimeException {
+
+  public BadRequestException() {
+    super();
+  }
+
+  public BadRequestException(String message) {
+    super(message);
+  }
+
+  public BadRequestException(Throwable cause) {
+    super(cause);
+  }
+
+  public BadRequestException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}


### PR DESCRIPTION
Add sorting parameters to the method TableController#getTablePartitions (amoro-ams).
Extend TableController#getTablePartitions with optional query parameters:

