### PR TITLE
ADH-7593 Add date filtering for snapshots

### DIFF
--- a/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/controller/TableController.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/controller/TableController.java
@@ -245,7 +245,8 @@ public class TableController {
         "Catalog %s does not support MIXED_HIVE format",
         catalog);
     // we should only keep MIXED_HIVE format，
-    // so `CatalogLoader.createCatalog` can get right CatalogImpl through calling catalogImpl.
+    // so `CatalogLoader.createCatalog` can get right CatalogImpl through calling
+    // catalogImpl.
     Map<String, String> originCatalogProperties = catalogMeta.getCatalogProperties();
     Map<String, String> catalogProperties = new HashMap<>(originCatalogProperties);
     catalogProperties.put(CatalogMetaProperties.TABLE_FORMATS, TableFormat.MIXED_HIVE.name());
@@ -781,12 +782,13 @@ public class TableController {
   }
 
   /**
-   * Builds a time range for filtering commits.
-   * Input times are in seconds (Unix timestamp); the returned range uses milliseconds.
+   * Builds a time range for filtering commits. Input times are in seconds (Unix timestamp); the
+   * returned range uses milliseconds.
    *
    * @param startTime start of the range in seconds (nullable)
    * @param endTime end of the range in seconds (nullable)
-   * @return Range in milliseconds: closed [start, end] if both set, atLeast/atMost if one set, all if neither
+   * @return Range in milliseconds: closed [start, end] if both set, atLeast/atMost if one set, all
+   *     if neither
    * @throws BadRequestException if both times are set and startTime &gt; endTime, or on overflow
    */
   private Range<Long> buildCommitTimeRange(Long startTime, Long endTime) {

--- a/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/controller/TableController.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/controller/TableController.java
@@ -106,6 +106,7 @@ import java.util.stream.Collectors;
 public class TableController {
   private static final Logger LOG = LoggerFactory.getLogger(TableController.class);
   private static final long UPGRADE_INFO_EXPIRE_INTERVAL = 60 * 60 * 1000;
+  private static final long MILLIS_PER_SECOND = 1000L;
   private static final HashSet<String> validPartitionsTableSortFields =
       new HashSet<>(
           Arrays.asList("partition", "specId", "fileCount", "fileSize", "lastCommitTime"));
@@ -410,12 +411,22 @@ public class TableController {
         ctx.queryParamAsClass("operation", String.class)
             .getOrDefault(OperationType.ALL.displayName());
     OperationType operationType = OperationType.of(operation);
+    // Date range filtering parameters (timestamps in seconds)
+    Long startTime = ctx.queryParamAsClass("startTime", Long.class).getOrDefault(null);
+    Long endTime = ctx.queryParamAsClass("endTime", Long.class).getOrDefault(null);
+    Range<Long> commitTimeRange = buildCommitTimeRange(startTime, endTime);
 
     List<AmoroSnapshotsOfTable> snapshotsOfTables =
         tableDescriptor.getSnapshots(
             TableIdentifier.of(catalog, database, tableName).buildTableIdentifier(),
             ref,
             operationType);
+
+    snapshotsOfTables =
+        snapshotsOfTables.stream()
+            .filter(snapshot -> commitTimeRange.contains(snapshot.getCommitTime()))
+            .collect(Collectors.toList());
+
     int offset = (page - 1) * pageSize;
     PageResult<AmoroSnapshotsOfTable> pageResult =
         PageResult.of(snapshotsOfTables, offset, pageSize);
@@ -767,6 +778,47 @@ public class TableController {
               branchInfos.remove(mainBranch);
               branchInfos.add(0, mainBranch);
             });
+  }
+
+  /**
+   * Builds a time range for filtering commits.
+   * Input times are in seconds (Unix timestamp); the returned range uses milliseconds.
+   *
+   * @param startTime start of the range in seconds (nullable)
+   * @param endTime end of the range in seconds (nullable)
+   * @return Range in milliseconds: closed [start, end] if both set, atLeast/atMost if one set, all if neither
+   * @throws BadRequestException if both times are set and startTime &gt; endTime, or on overflow
+   */
+  private Range<Long> buildCommitTimeRange(Long startTime, Long endTime) {
+    if (startTime != null && endTime != null && startTime > endTime) {
+      throw new BadRequestException("startTime must be less than or equal to endTime");
+    }
+
+    if (startTime != null && endTime != null) {
+      return Range.closed(toMillis(startTime, "startTime"), toMillis(endTime, "endTime"));
+    } else if (startTime != null) {
+      return Range.atLeast(toMillis(startTime, "startTime"));
+    } else if (endTime != null) {
+      return Range.atMost(toMillis(endTime, "endTime"));
+    } else {
+      return Range.all();
+    }
+  }
+
+  /**
+   * Converts seconds to milliseconds with overflow check.
+   *
+   * @param seconds time value in seconds
+   * @param paramName parameter name for error message on overflow
+   * @return time in milliseconds
+   * @throws BadRequestException if multiplication overflows (e.g. Long.MAX_VALUE)
+   */
+  private long toMillis(long seconds, String paramName) {
+    try {
+      return Math.multiplyExact(seconds, MILLIS_PER_SECOND);
+    } catch (ArithmeticException e) {
+      throw new BadRequestException(paramName + " is out of range", e);
+    }
   }
 
   private List<AMSColumnInfo> transformHiveSchemaToAMSColumnInfo(List<FieldSchema> fields) {

--- a/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/controller/TableController.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/controller/TableController.java
@@ -106,7 +106,6 @@ import java.util.stream.Collectors;
 public class TableController {
   private static final Logger LOG = LoggerFactory.getLogger(TableController.class);
   private static final long UPGRADE_INFO_EXPIRE_INTERVAL = 60 * 60 * 1000;
-  private static final long MILLIS_PER_SECOND = 1000L;
   private static final HashSet<String> validPartitionsTableSortFields =
       new HashSet<>(
           Arrays.asList("partition", "specId", "fileCount", "fileSize", "lastCommitTime"));
@@ -245,8 +244,7 @@ public class TableController {
         "Catalog %s does not support MIXED_HIVE format",
         catalog);
     // we should only keep MIXED_HIVE format，
-    // so `CatalogLoader.createCatalog` can get right CatalogImpl through calling
-    // catalogImpl.
+    // so `CatalogLoader.createCatalog` can get right CatalogImpl through calling catalogImpl.
     Map<String, String> originCatalogProperties = catalogMeta.getCatalogProperties();
     Map<String, String> catalogProperties = new HashMap<>(originCatalogProperties);
     catalogProperties.put(CatalogMetaProperties.TABLE_FORMATS, TableFormat.MIXED_HIVE.name());
@@ -817,7 +815,7 @@ public class TableController {
    */
   private long toMillis(long seconds, String paramName) {
     try {
-      return Math.multiplyExact(seconds, MILLIS_PER_SECOND);
+      return Math.multiplyExact(seconds, 1000L);
     } catch (ArithmeticException e) {
       throw new BadRequestException(paramName + " is out of range", e);
     }

--- a/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/controller/TableController.java
+++ b/amoro-ams/src/main/java/org/apache/amoro/server/dashboard/controller/TableController.java
@@ -58,6 +58,7 @@ import org.apache.amoro.server.persistence.TableRuntimeMeta;
 import org.apache.amoro.server.table.TableManager;
 import org.apache.amoro.shade.guava32.com.google.common.base.Function;
 import org.apache.amoro.shade.guava32.com.google.common.base.Preconditions;
+import org.apache.amoro.shade.guava32.com.google.common.collect.Range;
 import org.apache.amoro.shade.guava32.com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.amoro.shade.thrift.org.apache.thrift.TException;
 import org.apache.amoro.table.TableIdentifier;

--- a/amoro-ams/src/main/resources/openapi/openapi.yaml
+++ b/amoro-ams/src/main/resources/openapi/openapi.yaml
@@ -858,6 +858,80 @@ paths:
                         $ref: '#/components/schemas/PageResult'
         '400':
           description: Invalid sortBy parameter
+  /api/ams/v1/catalogs/{catalogName}/dbs/{db}/tables/{table}/snapshots:
+    get:
+      tags:
+        - Tables
+      summary: Get table snapshots
+      description: Get list of snapshots for a specific table with optional date range filtering
+      parameters:
+        - name: catalogName
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The name of the catalog
+        - name: db
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The database name
+        - name: table
+          in: path
+          required: true
+          schema:
+            type: string
+          description: The table name
+        - name: page
+          in: query
+          schema:
+            type: integer
+            default: 1
+          description: Page number
+        - name: pageSize
+          in: query
+          schema:
+            type: integer
+            default: 20
+          description: Number of items per page
+        - name: ref
+          in: query
+          schema:
+            type: string
+          description: Reference name (tag or branch)
+        - name: operation
+          in: query
+          schema:
+            type: string
+            default: ALL
+          description: Operation type filter (ALL, OPTIMIZING, NON_OPTIMIZING)
+        - name: startTime
+          in: query
+          schema:
+            type: integer
+            format: int64
+          description: Range start timestamp in seconds (inclusive). Filters snapshots with commitTime >= startTime.
+        - name: endTime
+          in: query
+          schema:
+            type: integer
+            format: int64
+          description: Range end timestamp in seconds (inclusive). Filters snapshots with commitTime <= endTime.
+      responses:
+        '200':
+          description: Successful response with paginated snapshot list
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Response'
+                  - type: object
+                    properties:
+                      result:
+                        $ref: '#/components/schemas/PageResult'
+        '400':
+          description: Bad request - invalid parameters (e.g., startTime > endTime, invalid timestamp format)
 components:
   securitySchemes:
     ApiKeyAuth:

--- a/amoro-ams/src/test/java/org/apache/amoro/server/dashboard/controller/TableControllerCommitTimeRangeTest.java
+++ b/amoro-ams/src/test/java/org/apache/amoro/server/dashboard/controller/TableControllerCommitTimeRangeTest.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.amoro.server.dashboard.controller;
+
+import org.apache.amoro.exception.BadRequestException;
+import org.apache.amoro.shade.guava32.com.google.common.collect.Range;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+
+/**
+ * Unit tests for {@link TableController#buildCommitTimeRange(Long, Long)}. Covers date range
+ * filtering for snapshots in the getTableSnapshots API (ADH-7495): both parameters, only startTime,
+ * only endTime, or neither (default behavior).
+ */
+public class TableControllerCommitTimeRangeTest {
+
+  /**
+   * Invokes the private {@code buildCommitTimeRange} method via reflection.
+   *
+   * @param startTime range start in seconds (inclusive), or null if not specified
+   * @param endTime range end in seconds (inclusive), or null if not specified
+   * @return the commit time range in milliseconds
+   * @throws Exception if reflection fails or the controller throws (e.g. BadRequestException)
+   */
+  @SuppressWarnings("unchecked")
+  private Range<Long> invokeBuildCommitTimeRange(Long startTime, Long endTime) throws Exception {
+    TableController controller = new TableController(null, null, null, null);
+    Method method =
+        TableController.class.getDeclaredMethod("buildCommitTimeRange", Long.class, Long.class);
+    method.setAccessible(true);
+    try {
+      return (Range<Long>) method.invoke(controller, startTime, endTime);
+    } catch (java.lang.reflect.InvocationTargetException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof Exception) {
+        throw (Exception) cause;
+      }
+      throw e;
+    }
+  }
+
+  /** Both startTime and endTime provided; range is [startTime, endTime] inclusive (in ms). */
+  @Test
+  public void testBuildCommitTimeRangeClosed() throws Exception {
+    Range<Long> range = invokeBuildCommitTimeRange(2L, 3L);
+
+    Assert.assertTrue(range.contains(2000L));
+    Assert.assertTrue(range.contains(2500L));
+    Assert.assertTrue(range.contains(3000L));
+    Assert.assertFalse(range.contains(1999L));
+    Assert.assertFalse(range.contains(3001L));
+  }
+
+  /** Only startTime provided; snapshots with commitTime >= startTime. */
+  @Test
+  public void testBuildCommitTimeRangeAtLeast() throws Exception {
+    Range<Long> range = invokeBuildCommitTimeRange(2L, null);
+
+    Assert.assertTrue(range.contains(2000L));
+    Assert.assertTrue(range.contains(Long.MAX_VALUE));
+    Assert.assertFalse(range.contains(1999L));
+  }
+
+  /** Only endTime provided; snapshots with commitTime <= endTime. */
+  @Test
+  public void testBuildCommitTimeRangeAtMost() throws Exception {
+    Range<Long> range = invokeBuildCommitTimeRange(null, 3L);
+
+    Assert.assertTrue(range.contains(3000L));
+    Assert.assertTrue(range.contains(Long.MIN_VALUE));
+    Assert.assertFalse(range.contains(3001L));
+  }
+
+  /** Neither startTime nor endTime provided; no date filtering (Range.all()). */
+  @Test
+  public void testBuildCommitTimeRangeAll() throws Exception {
+    Range<Long> range = invokeBuildCommitTimeRange(null, null);
+
+    Assert.assertTrue(range.contains(Long.MIN_VALUE));
+    Assert.assertTrue(range.contains(Long.MAX_VALUE));
+  }
+
+  /** startTime > endTime; expects BadRequestException (4xx). */
+  @Test(expected = BadRequestException.class)
+  public void testBuildCommitTimeRangeInvalidOrder() throws Exception {
+    invokeBuildCommitTimeRange(4L, 3L);
+  }
+
+  /** startTime causes overflow when converting to milliseconds; expects BadRequestException. */
+  @Test(expected = BadRequestException.class)
+  public void testBuildCommitTimeRangeOverflow() throws Exception {
+    invokeBuildCommitTimeRange(Long.MAX_VALUE, null);
+  }
+
+  /** Edge case: startTime == endTime; range is a single point in milliseconds. */
+  @Test
+  public void testBuildCommitTimeRangeSinglePoint() throws Exception {
+    Range<Long> range = invokeBuildCommitTimeRange(2L, 2L);
+
+    Assert.assertTrue(range.contains(2000L));
+    Assert.assertFalse(range.contains(1999L));
+    Assert.assertFalse(range.contains(2001L));
+  }
+
+  /** endTime causes overflow when converting to milliseconds; expects BadRequestException. */
+  @Test(expected = BadRequestException.class)
+  public void testBuildCommitTimeRangeOverflowEndTime() throws Exception {
+    invokeBuildCommitTimeRange(null, Long.MAX_VALUE);
+  }
+}


### PR DESCRIPTION
Extend the corresponding controller method TableController#getTableSnapshots with optional query parameters:

filtering behavior:

if both startTime and endTime are provided - return snapshots with commitTime within [startTime, endTime] (inclusive).
if only startTime is provided - return snapshots with commitTime >= startTime.
if only endTime is provided - return snapshots with commitTime <= endTime.
if neither parameter is provided - default behavior preserved (no date filtering; current behavior).