### PR TITLE
feature/build-fix: fix build error

### DIFF
--- a/amoro-optimizer/pom.xml
+++ b/amoro-optimizer/pom.xml
@@ -34,6 +34,7 @@
 
     <modules>
         <module>amoro-optimizer-common</module>
+        <module>amoro-optimizer-flink</module>
         <module>amoro-optimizer-spark</module>
         <module>amoro-optimizer-standalone</module>
     </modules>


### PR DESCRIPTION
## Why are the changes needed?

`mvn clean package -DskipTests` failed at the **`dist`** module during the **maven-assembly-plugin** step when building the binary distribution tarball.

The assembly descriptor (`dist/src/main/assemblies/bin.xml`) includes this file:

`amoro-optimizer/amoro-optimizer-flink/target/amoro-optimizer-flink-${project.version}-jar-with-dependencies.jar`

However, **`amoro-optimizer-flink` was not listed** under `<modules>` in `amoro-optimizer/pom.xml`, so it was **never built** as part of the reactor. As a result, the Flink optimizer JAR did not exist on disk and assembly failed with an error similar to:

`Failed to create assembly: Error adding file to archive: .../amoro-optimizer-flink/...-jar-with-dependencies.jar`

The Docker image build (`docker/amoro/Dockerfile`) expects `dist/target/*.tar.gz`, so a successful `dist` build is required for the documented compose workflow.

## Brief change log

- Register `amoro-optimizer-flink` as a Maven submodule of `amoro-optimizer` so it is built before `dist` packaging and the assembly can include the Flink optimizer plugin JAR.